### PR TITLE
chore(kanban): ensure checkout and node setup for label workflow

### DIFF
--- a/.github/workflows/auto-kanban-label.yml
+++ b/.github/workflows/auto-kanban-label.yml
@@ -8,6 +8,12 @@ jobs:
   label-sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
       - name: Choose token
         id: token
         run: |


### PR DESCRIPTION
Add checkout/setup-node steps so the label workflow can run scripts from the repository.